### PR TITLE
Fix the issue in deserialization and addition of merge method

### DIFF
--- a/theta/include/theta_sketch.hpp
+++ b/theta/include/theta_sketch.hpp
@@ -143,6 +143,8 @@ public:
   // which does widening conversion to int64_t, if compatibility with Java is expected
   void update(const void* data, unsigned length);
 
+  void merge(const theta_sketch_alloc<A>& sketch);
+  
   compact_theta_sketch_alloc<A> compact(bool ordered = true) const;
 
   virtual typename theta_sketch_alloc<A>::const_iterator begin() const;

--- a/theta/include/theta_sketch_impl.hpp
+++ b/theta/include/theta_sketch_impl.hpp
@@ -463,7 +463,7 @@ update_theta_sketch_alloc<A> update_theta_sketch_alloc<A>::internal_deserialize(
   uint64_t* keys = AllocU64().allocate(1 << lg_cur_size);
   is.read((char*)keys, sizeof(uint64_t) * (1 << lg_cur_size));
   const bool is_empty = flags_byte & (1 << theta_sketch_alloc<A>::flags::IS_EMPTY);
-  return update_theta_sketch_alloc<A>(is_empty, theta, lg_nom_size, lg_cur_size, keys, num_keys, rf, p, seed);
+  return update_theta_sketch_alloc<A>(is_empty, theta, lg_cur_size, lg_nom_size, keys, num_keys, rf, p, seed);
 }
 
 template<typename A>
@@ -506,7 +506,7 @@ update_theta_sketch_alloc<A> update_theta_sketch_alloc<A>::internal_deserialize(
   uint64_t* keys = AllocU64().allocate(table_size);
   copy_from_mem(&ptr, keys, sizeof(uint64_t) * table_size);
   const bool is_empty = flags_byte & (1 << theta_sketch_alloc<A>::flags::IS_EMPTY);
-  return update_theta_sketch_alloc<A>(is_empty, theta, lg_nom_size, lg_cur_size, keys, num_keys, rf, p, seed);
+  return update_theta_sketch_alloc<A>(is_empty, theta, lg_cur_size, lg_nom_size, keys, num_keys, rf, p, seed);
 }
 
 template<typename A>


### PR DESCRIPTION
The passed parameters 'lg_nom_size' and 'lg_cur_size' are not in correct order. They should be passed as 'lg_cur_size' and  'lg_nom_size' because the actual call is as below:
  // for deserialize
  update_theta_sketch_alloc(bool is_empty, uint64_t theta, uint8_t lg_cur_size, uint8_t lg_nom_size, uint64_t* keys, uint32_t num_keys, resize_factor rf, float p, uint64_t seed);